### PR TITLE
Increase total wait time if file busy

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,9 +130,13 @@ func main() {
 
 			err = runBin(bin, args)
 			// https://github.com/golang/go/issues/22220
-			if err != nil && nbusy < 3 && strings.Contains(err.Error(), "text file busy") {
+			if err != nil && nbusy < 100 && strings.Contains(err.Error(), "text file busy") {
 				log.Println("Text file busy - retry in a bit")
-				time.Sleep(100 * time.Millisecond << uint(nbusy))
+				twait := 10 * time.Second
+				if nbusy < 7 {
+					twait = 100 * time.Millisecond << uint(nbusy)
+				}
+				time.Sleep(twait)
 				nbusy++
 				continue
 			}


### PR DESCRIPTION
Previously would only try 3 times, for max total 700 ms.  This might not be enough for some slow processes.  
With this change goes up to 100 times.  With backoff, the retries will be at intervals

100ms  -  100ms
200ms  -  300ms
400ms  -  700ms
800ms  -  1.5s
1.6s  -  3.1s
3.2s  -  6.3s
6.4s  -  12.7s
10s  -  22.7s
... and tries every 10s after this for about 15m max, after that will exit